### PR TITLE
Add --nouniq option

### DIFF
--- a/src/bin/ropr.rs
+++ b/src/bin/ropr.rs
@@ -129,7 +129,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 		.map(|r| Regex::new(&r))
 		.collect::<Result<Vec<_>, _>>()?;
 
-	let deduped = sections
+	let gadget_to_addr = sections
 		.iter()
 		.filter_map(Disassembly::new)
 		.flat_map(|dis| {
@@ -151,7 +151,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 		})
 		.collect::<HashMap<_, _>>();
 
-	let mut gadgets = deduped
+	let mut gadgets = gadget_to_addr
 		.into_iter()
 		.filter(|(g, _)| {
 			let mut formatted = String::new();

--- a/src/bin/ropr.rs
+++ b/src/bin/ropr.rs
@@ -62,6 +62,10 @@ struct Opt {
 	#[clap(long)]
 	range: Vec<String>,
 
+	/// Show duplicated gadgets
+	#[clap(short = 'u', long)]
+	nouniq: bool,
+
 	/// The path of the file to inspect
 	binary: PathBuf,
 }
@@ -93,6 +97,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 	let rop = !opts.norop;
 	let sys = !opts.nosys;
 	let jop = !opts.nojop;
+	let uniq = !opts.nouniq;
 	let stack_pivot = opts.stack_pivot;
 	let base_pivot = opts.base_pivot;
 	let max_instructions_per_gadget = opts.max_instr as usize;
@@ -132,7 +137,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 				.into_par_iter()
 				.filter(|offset| dis.is_tail_at(*offset, rop, sys, jop, noisy))
 				.flat_map_iter(|tail| {
-					dis.gadgets_from_tail(tail, max_instructions_per_gadget, noisy)
+					dis.gadgets_from_tail(tail, max_instructions_per_gadget, noisy, uniq)
 				})
 				.collect::<Vec<_>>()
 		})

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -85,6 +85,7 @@ impl<'b> Disassembly<'b> {
 		tail_index: usize,
 		max_instructions: usize,
 		noisy: bool,
+		uniq: bool
 	) -> GadgetIterator {
 		assert!(max_instructions > 0);
 		let start_index =
@@ -97,6 +98,7 @@ impl<'b> Disassembly<'b> {
 			predecessors,
 			max_instructions,
 			noisy,
+			uniq,
 			start_index,
 		)
 	}

--- a/src/gadgets.rs
+++ b/src/gadgets.rs
@@ -7,6 +7,7 @@ use std::hash::Hash;
 #[derive(Debug, Eq, Hash, PartialEq)]
 pub struct Gadget {
 	instructions: Vec<Instruction>,
+	unique_id: usize
 }
 
 impl Gadget {
@@ -55,6 +56,7 @@ pub struct GadgetIterator<'d> {
 	predecessors: &'d [Instruction],
 	max_instructions: usize,
 	noisy: bool,
+	uniq: bool,
 	start_index: usize,
 	finished: bool,
 }
@@ -66,6 +68,7 @@ impl<'d> GadgetIterator<'d> {
 		predecessors: &'d [Instruction],
 		max_instructions: usize,
 		noisy: bool,
+		uniq: bool,
 		start_index: usize,
 	) -> Self {
 		Self {
@@ -74,6 +77,7 @@ impl<'d> GadgetIterator<'d> {
 			predecessors,
 			max_instructions,
 			noisy,
+			uniq,
 			start_index,
 			finished: false,
 		}
@@ -110,8 +114,13 @@ impl Iterator for GadgetIterator<'_> {
 			if index == len {
 				instructions.push(self.tail_instruction);
 				// instructions.shrink_to_fit();
+				let unique_id = if self.uniq {
+					0
+				} else {
+					self.section_start + current_start_index
+				};
 				return Some((
-					Gadget { instructions },
+					Gadget { instructions, unique_id },
 					self.section_start + current_start_index,
 				));
 			}
@@ -121,8 +130,13 @@ impl Iterator for GadgetIterator<'_> {
 			self.finished = true;
 			instructions.clear();
 			instructions.push(self.tail_instruction);
+			let unique_id = if self.uniq {
+				0
+			} else {
+				self.section_start + self.start_index
+			};
 			return Some((
-				Gadget { instructions },
+				Gadget { instructions, unique_id },
 				self.section_start + self.start_index,
 			));
 		}


### PR DESCRIPTION
## Description
This PR introduces a new option `--nouniq` or `-u`, which enables ropr to show non-unique gadgets.

## Motivation and Context
The current ropr deduplicates gadgets and shows only unique ones.
However, sometimes it's desirable to see every gadget available.
(i.e. avoid 0x0A in the gadget address / use gadgets with lower address for kernel exploitation)

## Changes
I've added a new field `unique_id` to `Gadget` struct.
This field is set to the address of the gadget when --nouniq is enabled, otherwise 0.
This change can switch the behavior when it's inserted into `HashMap`.

## How Has This Been Tested?
I've tested some gadgets such as `pop rax; ret;` on libc binary and checked if it outputs the same gadgets as those by rp-lin-x64.