### PR TITLE
Add -z to work with relative offsets in case of PE files

### DIFF
--- a/src/bin/ropr.rs
+++ b/src/bin/ropr.rs
@@ -70,6 +70,10 @@ struct Opt {
 	#[clap(short = 'u', long)]
 	nouniq: bool,
 
+	/// Zero out image base addres to show relative offsets
+	#[clap(short = 'z', long)]
+	zero_base: bool,
+
 	/// The path of the file to inspect
 	binary: PathBuf,
 }
@@ -94,7 +98,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 	let b = opts.binary;
 	let b = Binary::new(b)?;
-	let sections = b.sections(opts.raw)?;
+	let sections = b.sections(opts.raw, opts.zero_base)?;
 
 	let noisy = opts.noisy;
 	let colour = opts.colour;

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -26,7 +26,7 @@ impl Binary {
 
 	pub fn path(&self) -> &Path { &self.path }
 
-	pub fn sections(&self, raw: Option<bool>) -> Result<Vec<Section>> {
+	pub fn sections(&self, raw: Option<bool>, zero: bool) -> Result<Vec<Section>> {
 		match raw {
 			Some(true) => Ok(vec![Section {
 				file_offset: 0,
@@ -78,7 +78,7 @@ impl Binary {
 							Section {
 								file_offset: start_offset,
 								section_vaddr: section.virtual_address as usize,
-								program_base: p.image_base,
+								program_base: if zero { 0 } else { p.image_base },
 								bytes: &self.bytes[start_offset..end_offset],
 								bitness,
 							}
@@ -133,7 +133,7 @@ impl Binary {
 							Section {
 								file_offset: start_offset,
 								section_vaddr: section.virtual_address as usize,
-								program_base: p.image_base,
+								program_base: if zero { 0 } else { p.image_base },
 								bytes: &self.bytes[start_offset..end_offset],
 								bitness,
 							}


### PR DESCRIPTION
Usually I find it more useful to work with relative file offsets instead of absolute ones because base addresses tend to change because of ASLR. 

This PR add the `-z` command line option that sets the image base address to 0 in `Section` objects so relative addresses are displayed in case of PE files too. 

Note: I'm not too experienced in Rust. I used a plain old `bool` data type for the new [flag](https://docs.rs/clap/latest/clap/_derive/_tutorial/index.html#flags) that is recommended by _clap_'s documentation, but inconsistent with `--raw` that is also passed to the `Section` constructor.